### PR TITLE
Add Customization of Logged Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.0
+
+- Added Settings Dialog to allow for customizing of what settings are logged.
+- Added option to record Profile Name and Filament Names
+
 ## 1.1.0
 
 - Added support for multiple extruders

--- a/PrintLogSettingDefinitionsModel.py
+++ b/PrintLogSettingDefinitionsModel.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2019 fieldOfView
+# The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
+
+from UM.Settings.Models.SettingDefinitionsModel import SettingDefinitionsModel
+
+
+class PrintLogSettingDefinitionsModel(SettingDefinitionsModel):
+
+    def __init__(self, parent=None, *args, **kwargs):
+        super().__init__(parent=parent, *args, **kwargs)
+
+    def _isDefinitionVisible(self, definition, **kwargs):
+        # filter out any setting that is irrelevant for an extruder/material
+        # if getattr(definition, "settable_per_extruder") == False and getattr(definition, "resolve") is None:
+        #     return False
+
+        return super()._isDefinitionVisible(definition, **kwargs)

--- a/PrintLogSettingDefinitionsModel.py
+++ b/PrintLogSettingDefinitionsModel.py
@@ -1,6 +1,3 @@
-# Copyright (c) 2019 fieldOfView
-# The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
-
 from UM.Settings.Models.SettingDefinitionsModel import SettingDefinitionsModel
 
 
@@ -10,8 +7,4 @@ class PrintLogSettingDefinitionsModel(SettingDefinitionsModel):
         super().__init__(parent=parent, *args, **kwargs)
 
     def _isDefinitionVisible(self, definition, **kwargs):
-        # filter out any setting that is irrelevant for an extruder/material
-        # if getattr(definition, "settable_per_extruder") == False and getattr(definition, "resolve") is None:
-        #     return False
-
         return super()._isDefinitionVisible(definition, **kwargs)

--- a/PrintLogSettingsVisibilityHandler.py
+++ b/PrintLogSettingsVisibilityHandler.py
@@ -5,6 +5,8 @@ from UM.FlameProfiler import pyqtSlot
 
 
 class PrintLogSettingsVisibilityHandler(SettingVisibilityHandler):
+    '''Create a custom visibility handler so we can hide/show settings in the dialogs.'''
+
     def __init__(self, parent=None, *args, **kwargs):
         super().__init__(parent=parent, *args, **kwargs)
 

--- a/PrintLogSettingsVisibilityHandler.py
+++ b/PrintLogSettingsVisibilityHandler.py
@@ -1,0 +1,49 @@
+from UM.Settings.Models.SettingVisibilityHandler import SettingVisibilityHandler
+from UM.Application import Application
+
+from UM.FlameProfiler import pyqtSlot
+
+
+class PrintLogSettingsVisibilityHandler(SettingVisibilityHandler):
+    def __init__(self, parent=None, *args, **kwargs):
+        super().__init__(parent=parent, *args, **kwargs)
+
+        self._preferences = Application.getInstance().getPreferences()
+        self._preferences.preferenceChanged.connect(self._onPreferencesChanged)
+
+        self._onPreferencesChanged("3d_print_log/logged_settings")
+        self.visibilityChanged.connect(self._updatePreference)
+
+    def _onPreferencesChanged(self, name: str) -> None:
+        if name != "3d_print_log/logged_settings":
+            return
+
+        visibility_string = self._preferences.getValue(
+            "3d_print_log/logged_settings")
+        if not visibility_string:
+            self._preferences.resetPreference(
+                "3d_print_log/logged_settings")
+            return
+
+        material_settings = set(visibility_string.split(";"))
+        if material_settings != self.getVisible():
+            self.setVisible(material_settings)
+
+    def _updatePreference(self) -> None:
+        visibility_string = ";".join(self.getVisible())
+        self._preferences.setValue(
+            "3d_print_log/logged_settings", visibility_string)
+
+    # Set a single SettingDefinition's visible state
+    @pyqtSlot(str, bool)
+    def setSettingVisibility(self, key: str, visible: bool) -> None:
+        visible_settings = self.getVisible()
+        if visible:
+            visible_settings.add(key)
+        else:
+            try:
+                visible_settings.remove(key)
+            except KeyError:
+                pass
+
+        self.setVisible(visible_settings)

--- a/PrintLogUploader.py
+++ b/PrintLogUploader.py
@@ -39,9 +39,11 @@ class PrintLogUploader(QObject, Extension):
     '''
 
     plugin_version = "1.2.0"
-    new_print_url = "https://localhost:4200/prints/new/cura"
-    api_url = "https://localhost:5001/api/Cura/settings"
-    # new_print_url = "https://www.3dprintlog.com/prints/new/cura"
+    # new_print_url = "https://localhost:4200/prints/new/cura"
+    # api_url = "https://localhost:5001/api/Cura/settings"
+
+    new_print_url = "https://www.3dprintlog.com/prints/new/cura"
+    api_url = "https://api.3dprintlog.com/api/Cura/settings"
 
     default_logged_settings = {
         "layer_height",

--- a/PrintLogUploader.py
+++ b/PrintLogUploader.py
@@ -68,6 +68,14 @@ class PrintLogUploader(QObject, Extension):
             "3d_print_log/logged_settings",
             ";".join(default_logged_settings)
         )
+        CuraApplication.getInstance().getPreferences().addPreference(
+            "3d_print_log/include_profile_name",
+            True
+        )
+        CuraApplication.getInstance().getPreferences().addPreference(
+            "3d_print_log/include_filament_name",
+            False
+        )
 
         CuraApplication.getInstance().engineCreatedSignal.connect(self._onEngineCreated)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Once installed, a prompt will be displayed asking if you would like to send the 
 
 This will only prepopulate the form, no information is saved until you save the form in 3D Print Log.
 
+## Settings
+
+What settings that are logged can be modified through the `Extensions -> 3D Print Log -> Configure Settings to Log` menu option. Here you can select what settings will be sent to 3D Print Log.
+
 ## Contributing
 
 Want to contribute? Feel free to create issues and pull requests! Or leave feedback directly at [3D Print Log's Feedback](https://www.3dprintlog.com/feedback). Let me know what features you would like to see.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,7 @@
 from . import PrintLogUploader
+from . import PrintLogSettingDefinitionsModel
+
+from PyQt5.QtQml import qmlRegisterType
 
 
 def getMetaData():
@@ -6,4 +9,7 @@ def getMetaData():
 
 
 def register(app):
+    qmlRegisterType(PrintLogSettingDefinitionsModel.PrintLogSettingDefinitionsModel,
+                    "PrintLogUploader", 1, 0, "PrintLogSettingDefinitionsModel")
+
     return {"extension": PrintLogUploader.PrintLogUploader()}

--- a/plugin.json
+++ b/plugin.json
@@ -3,5 +3,5 @@
   "author": "Hoffman Engineering",
   "version": "1.2.0",
   "description": "Send Print details to 3D Print Log",
-  "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0"]
+  "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Send Print details to 3D Print Log",
   "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0"]
 }

--- a/qml/SettingCategory.qml
+++ b/qml/SettingCategory.qml
@@ -1,6 +1,3 @@
-// Copyright (c) 2019 fieldOfView
-// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
-
 import QtQuick 2.2
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1

--- a/qml/SettingCategory.qml
+++ b/qml/SettingCategory.qml
@@ -1,0 +1,62 @@
+// Copyright (c) 2019 fieldOfView
+// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
+import QtQuick.Layouts 1.1
+
+import UM 1.1 as UM
+
+import ".."
+
+Button {
+    id: base;
+
+    style: ButtonStyle {
+        background: Item { }
+        label: Row
+        {
+            spacing: UM.Theme.getSize("default_lining").width
+
+            UM.RecolorImage
+            {
+                anchors.verticalCenter: parent.verticalCenter
+                height: (label.height / 2) | 0
+                width: height
+                source: control.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_right");
+                color: control.hovered ? palette.highlight : palette.buttonText
+            }
+            UM.RecolorImage
+            {
+                anchors.verticalCenter: parent.verticalCenter
+                height: label.height
+                width: height
+                source: control.iconSource
+                color: control.hovered ? palette.highlight : palette.buttonText
+            }
+            Label
+            {
+                id: label
+                anchors.verticalCenter: parent.verticalCenter
+                text: control.text
+                color: control.hovered ? palette.highlight : palette.buttonText
+                font.bold: true
+            }
+
+            SystemPalette { id: palette }
+        }
+    }
+
+    signal showTooltip(string text);
+    signal hideTooltip();
+    signal contextMenuRequested()
+
+    text: definition.label
+    iconSource: UM.Theme.getIcon(definition.icon)
+
+    checkable: true
+    checked: definition.expanded
+
+    onClicked: definition.expanded ? settingDefinitionsModel.collapse(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
+}

--- a/qml/SettingItem.qml
+++ b/qml/SettingItem.qml
@@ -1,6 +1,3 @@
-// Copyright (c) 2019 fieldOfView
-// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
-
 import QtQuick 2.1
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.1

--- a/qml/SettingItem.qml
+++ b/qml/SettingItem.qml
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 fieldOfView
+// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.1
+import QtQuick.Layouts 1.1
+import QtQuick.Controls 1.1
+import QtQuick.Controls.Styles 1.1
+
+import UM 1.2 as UM
+
+UM.TooltipArea
+{
+    x: model.depth * UM.Theme.getSize("default_margin").width;
+    text: model.description;
+
+    width: childrenRect.width;
+    height: childrenRect.height;
+
+    CheckBox
+    {
+        id: check
+
+        text: definition.label
+        checked: definition.visible;
+
+        onClicked:
+        {
+            definitionsModel.visibilityHandler.setSettingVisibility(model.key, checked);
+        }
+    }
+}
+
+

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -36,87 +36,154 @@ UM.Dialog {
         listview.model.filter = new_filter;
     }
 
-    TextField {
-        id: filterInput
-
-        anchors {
-            top: parent.top
-            left: parent.left
-            right: toggleShowAll.left
-            rightMargin: UM.Theme.getSize("default_margin").width
-        }
-
-        placeholderText: catalog.i18nc("@label:textbox", "Filter...");
-
-        onTextChanged: settingsDialog.updateFilter()
-    }
-
-    CheckBox
+    Column
     {
-        id: toggleShowAll
+        width: parent.width
+        height: parent.height
 
-        anchors {
-            top: parent.top
-            right: parent.right
+        Label
+        {
+            font.bold: true
+            text: "General"
         }
 
-        text: catalog.i18nc("@label:checkbox", "Show all")
-        checked: listview.model.showAll
-        onClicked:
+        UM.TooltipArea
         {
-            listview.model.showAll = checked;
-        }
-    }
+            width: childrenRect.width;
+            height: childrenRect.height;
 
-    ScrollView
-    {
-        id: scrollView
+            text: "Include profile name in the Notes field."
 
-        anchors
-        {
-            top: filterInput.bottom;
-            left: parent.left;
-            right: parent.right;
-            bottom: parent.bottom;
-        }
-        ListView
-        {
-            id:listview
-            model: PrintLogUploader.PrintLogSettingDefinitionsModel
+            CheckBox
             {
-                id: definitionsModel;
-                containerId: Cura.MachineManager.activeMachine.definition.id
-                visibilityHandler: Cura.PrintLogSettingsVisibilityHandler {}
-                showAll: true
-                showAncestors: true
-                expanded: [ "*" ]
-                exclude: [ "machine_settings", "command_line_settings" ]
+                id: includeProfileNameCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_profile_name")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_profile_name", checked)
+
+                text: "Include Profile Name"
             }
-            delegate:Loader
+        }
+
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Include filament/material name in the Notes field."
+
+            CheckBox
             {
-                id: loader
+                id: includeFilamentNameCheckbox
 
-                width: parent.width
-                height: model.type != undefined ? UM.Theme.getSize("section").height : 0;
+                checked: UM.Preferences.getValue("3d_print_log/include_filament_name")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_filament_name",  checked)
 
-                property var definition: model
-                property var settingDefinitionsModel: definitionsModel
+                text: "Include Filament Name"
+            }
+        }
 
-                asynchronous: true
-                source:
+        Item
+        {
+            //: Spacer
+            height: UM.Theme.getSize("default_margin").height
+            width: UM.Theme.getSize("default_margin").width
+        }
+
+        Label
+        {
+            id: settingLabel
+            font.bold: true
+            text: "Settings"
+        }
+
+        Row {
+            id: settingSearchRow
+            width: parent.width
+
+            TextField {
+
+                id: filterInput
+                width: settingSearchRow.width - searchSpacer.width - toggleShowAll.width
+                placeholderText: catalog.i18nc("@label:textbox", "Filter...");
+
+                onTextChanged: settingsDialog.updateFilter()
+            }
+
+            Item
+            {
+                id: searchSpacer
+                //: Spacer
+                height: UM.Theme.getSize("default_margin").height
+                width: UM.Theme.getSize("default_margin").width
+            }
+
+            CheckBox
+            {
+                id: toggleShowAll
+                
+                text: catalog.i18nc("@label:checkbox", "Show all")
+                checked: listview.model.showAll
+                onClicked:
                 {
-                    switch(model.type)
-                    {
-                        case "category":
-                            return "SettingCategory.qml"
-                        default:
-                            return "SettingItem.qml"
-                    }
+                    listview.model.showAll = checked;
                 }
             }
-            Component.onCompleted: settingsDialog.updateFilter()
+        }
+
+        ScrollView
+        {
+            id: scrollView
+
+
+            anchors
+            {
+
+                left: parent.left;
+                right: parent.right;
+
+            }
+            ListView
+            {
+                id:listview
+                model: PrintLogUploader.PrintLogSettingDefinitionsModel
+                {
+                    id: definitionsModel;
+                    containerId: Cura.MachineManager.activeMachine.definition.id
+                    visibilityHandler: Cura.PrintLogSettingsVisibilityHandler {}
+                    showAll: true
+                    showAncestors: true
+                    expanded: [ "*" ]
+                    exclude: [ "machine_settings", "command_line_settings" ]
+                }
+                delegate:Loader
+                {
+                    id: loader
+
+                    width: parent.width
+                    height: model.type != undefined ? UM.Theme.getSize("section").height : 0;
+
+                    property var definition: model
+                    property var settingDefinitionsModel: definitionsModel
+
+                    asynchronous: true
+                    source:
+                    {
+                        switch(model.type)
+                        {
+                            case "category":
+                                return "SettingCategory.qml"
+                            default:
+                                return "SettingItem.qml"
+                        }
+                    }
+                }
+                Component.onCompleted: settingsDialog.updateFilter()
+            }
         }
     }
+    
 
     rightButtons: [
         Button {

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -5,6 +5,7 @@ import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
 import QtQuick.Window 2.2
+import QtQuick.Layouts 1.1
 
 import UM 1.2 as UM
 import Cura 1.0 as Cura
@@ -36,10 +37,9 @@ UM.Dialog {
         listview.model.filter = new_filter;
     }
 
-    Column
+    ColumnLayout
     {
-        width: parent.width
-        height: parent.height
+        anchors.fill: parent
 
         Label
         {
@@ -100,7 +100,7 @@ UM.Dialog {
 
         Row {
             id: settingSearchRow
-            width: parent.width
+            Layout.fillWidth: true
 
             TextField {
 
@@ -135,15 +135,9 @@ UM.Dialog {
         ScrollView
         {
             id: scrollView
+            Layout.fillHeight: true
+            Layout.fillWidth: true
 
-
-            anchors
-            {
-
-                left: parent.left;
-                right: parent.right;
-
-            }
             ListView
             {
                 id:listview

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -181,6 +181,20 @@ UM.Dialog {
 
     rightButtons: [
         Button {
+            text: catalog.i18nc("@action:button", "Reset To Defaults");
+            onClicked: {
+                UM.Preferences.resetPreference("3d_print_log/logged_settings")
+                
+                UM.Preferences.resetPreference("3d_print_log/include_profile_name")
+                includeProfileNameCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_profile_name")
+
+                UM.Preferences.resetPreference("3d_print_log/include_filament_name")
+                includeFilamentNameCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_filament_name")
+                
+                settingsDialog.visible = false;
+            }
+        },
+        Button {
             text: catalog.i18nc("@action:button", "Close");
             onClicked: {
                 settingsDialog.visible = false;

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -8,7 +8,7 @@ import QtQuick.Window 2.2
 
 import UM 1.2 as UM
 import Cura 1.0 as Cura
-import MaterialSettingsPlugin 1.0 as MaterialSettingsPlugin
+import PrintLogUploader 1.0 as PrintLogUploader
 
 UM.Dialog {
     id: settingsDialog

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -1,6 +1,3 @@
-// Copyright (c) 2019 fieldOfView
-// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
-
 import QtQuick 2.2
 import QtQuick.Controls 1.2
 import QtQuick.Controls.Styles 1.2
@@ -178,9 +175,12 @@ UM.Dialog {
         }
     }
     
-
     rightButtons: [
         Button {
+            anchors {
+                rightMargin: UM.Theme.getSize("default_margin").width
+            }
+            
             text: catalog.i18nc("@action:button", "Reset To Defaults");
             onClicked: {
                 UM.Preferences.resetPreference("3d_print_log/logged_settings")
@@ -193,6 +193,12 @@ UM.Dialog {
                 
                 settingsDialog.visible = false;
             }
+        },
+        Item
+        {
+            //: Spacer
+            height: UM.Theme.getSize("default_margin").height
+            width: UM.Theme.getSize("default_margin").width
         },
         Button {
             text: catalog.i18nc("@action:button", "Close");

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -1,0 +1,134 @@
+// Copyright (c) 2019 fieldOfView
+// The MaterialSettingsPlugin is released under the terms of the AGPLv3 or higher.
+
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Controls.Styles 1.2
+import QtQuick.Window 2.2
+
+import UM 1.2 as UM
+import Cura 1.0 as Cura
+import MaterialSettingsPlugin 1.0 as MaterialSettingsPlugin
+
+UM.Dialog {
+    id: settingsDialog
+
+    title: catalog.i18nc("@title:window", "Select Settings to Log")
+    width: screenScaleFactor * 360
+
+    onVisibilityChanged:
+    {
+        if(visible)
+        {
+            updateFilter()
+        }
+    }
+
+    function updateFilter()
+    {
+        var new_filter = {};
+
+        if(filterInput.text != "")
+        {
+            new_filter["i18n_label"] = "*" + filterInput.text;
+        }
+
+        listview.model.filter = new_filter;
+    }
+
+    TextField {
+        id: filterInput
+
+        anchors {
+            top: parent.top
+            left: parent.left
+            right: toggleShowAll.left
+            rightMargin: UM.Theme.getSize("default_margin").width
+        }
+
+        placeholderText: catalog.i18nc("@label:textbox", "Filter...");
+
+        onTextChanged: settingsDialog.updateFilter()
+    }
+
+    CheckBox
+    {
+        id: toggleShowAll
+
+        anchors {
+            top: parent.top
+            right: parent.right
+        }
+
+        text: catalog.i18nc("@label:checkbox", "Show all")
+        checked: listview.model.showAll
+        onClicked:
+        {
+            listview.model.showAll = checked;
+        }
+    }
+
+    ScrollView
+    {
+        id: scrollView
+
+        anchors
+        {
+            top: filterInput.bottom;
+            left: parent.left;
+            right: parent.right;
+            bottom: parent.bottom;
+        }
+        ListView
+        {
+            id:listview
+            model: PrintLogUploader.PrintLogSettingDefinitionsModel
+            {
+                id: definitionsModel;
+                containerId: Cura.MachineManager.activeMachine.definition.id
+                visibilityHandler: Cura.PrintLogSettingsVisibilityHandler {}
+                showAll: true
+                showAncestors: true
+                expanded: [ "*" ]
+                exclude: [ "machine_settings", "command_line_settings" ]
+            }
+            delegate:Loader
+            {
+                id: loader
+
+                width: parent.width
+                height: model.type != undefined ? UM.Theme.getSize("section").height : 0;
+
+                property var definition: model
+                property var settingDefinitionsModel: definitionsModel
+
+                asynchronous: true
+                source:
+                {
+                    switch(model.type)
+                    {
+                        case "category":
+                            return "SettingCategory.qml"
+                        default:
+                            return "SettingItem.qml"
+                    }
+                }
+            }
+            Component.onCompleted: settingsDialog.updateFilter()
+        }
+    }
+
+    rightButtons: [
+        Button {
+            text: catalog.i18nc("@action:button", "Close");
+            onClicked: {
+                settingsDialog.visible = false;
+            }
+        }
+    ]
+
+    Item
+    {
+        UM.I18nCatalog { id: catalog; name: "cura"; }
+    }
+}


### PR DESCRIPTION
Introduces a new setting dialog which allows a user to customize what settings they want recorded. The selected settings are then formatted into a note field, and that information is send to the 3D Print Log Api. The browser is then opened and the new Print form on 3Dprintlog.com is populated with that new customized information.