### PR TITLE
Add snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.1
+
+- Added ability to send a snapshot of the build plate as the print image. (Enabled by default).
+
 ## 1.2.0
 
 - Added Settings Dialog to allow for customizing of what settings are logged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Added Settings Dialog to allow for customizing of what settings are logged.
 - Added option to record Profile Name and Filament Names
+- Minimum supported version: Cura 4.5
 
 ## 1.1.0
 

--- a/PrintLogUploader.py
+++ b/PrintLogUploader.py
@@ -37,9 +37,9 @@ class PrintLogUploader(QObject, Extension):
     Requires the user to have an account and be logged into 3D Print Log before they can save any information.
     '''
 
-    plugin_version = "1.2.0"
     # new_print_url = "https://localhost:4200/prints/new/cura"
     # api_url = "https://localhost:5001/api/Cura/settings"
+    plugin_version = "1.2.1"
 
     new_print_url = "https://www.3dprintlog.com/prints/new/cura"
     api_url = "https://api.3dprintlog.com/api/Cura/settings"
@@ -158,7 +158,7 @@ class PrintLogUploader(QObject, Extension):
             include_snapshot = preferences.getValue(
                 "3d_print_log/include_snapshot")
             if (include_snapshot):
-                snapshot = self.generateSnapshot()
+                snapshot = self._generateSnapshot()
 
                 if snapshot:
                     settings["snapshot"] = snapshot.data(
@@ -290,7 +290,8 @@ class PrintLogUploader(QObject, Extension):
         url = self.new_print_url + "?" + query_params
         webbrowser.open(url, new=0, autoraise=True)
 
-    def generateSnapshot(self) -> Optional[QBuffer]:
+    def _generateSnapshot(self) -> Optional[QBuffer]:
+        '''Grabs the snapshot from the Cura Backend if one exists and returns it as a buffer.'''
         try:
             Logger.log("i", "Generating Snapshot")
             # Attempt to store the thumbnail, if any:
@@ -298,40 +299,21 @@ class PrintLogUploader(QObject, Extension):
             snapshot = None if getattr(
                 backend, "getLatestSnapshot", None) is None else backend.getLatestSnapshot()
 
-            # snapshot = None
-            # if not CuraApplication.getInstance().isVisible:
-            #     Logger.log(
-            #         "i", "Can't create snapshot when renderer not initialized.")
-            #     return None
-            # Logger.log("i", "Creating thumbnail image.")
-            # try:
-            #     snapshot = Snapshot.snapshot(width=600, height=600)
-            # except:
-            #     Logger.log("e", "Failed to create snapshot image")
-            #     return None  # Failing to create thumbnail should not fail creation of UFP
-
             if snapshot:
                 Logger.log("i", "Snapshot Found")
-
-                # thumbnail = archive.getStream("/Metadata/thumbnail.png")
 
                 thumbnail_buffer = QBuffer()
                 thumbnail_buffer.open(QBuffer.ReadWrite)
                 snapshot.save(thumbnail_buffer, "PNG")
 
-                # f = open('C:/Temp/Snapshot.png', 'wb')
-                # f.write(thumbnail_buffer.data())
-                # f.close()
                 return thumbnail_buffer
             else:
                 Logger.log("i", "No Snapshot Found")
                 return None
 
-                # thumbnail.write(thumbnail_buffer.data())
-
         except Exception:
             Logger.logException(
-                "e", "Exception raised saving snapshot")
+                "e", "Exception raised while saving snapshot")
             return None
 
     def _getCuraMetadata(self):

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Send Print details to 3D Print Log",
   "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -3,5 +3,5 @@
   "author": "Hoffman Engineering",
   "version": "1.2.1",
   "description": "Send Print details to 3D Print Log",
-  "supported_sdk_versions": ["6.0.0", "6.1.0", "6.2.0", "6.3.0", "7.0.0", "7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0"]
+  "supported_sdk_versions": ["7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0"]
 }

--- a/qml/SettingsDialog.qml
+++ b/qml/SettingsDialog.qml
@@ -81,6 +81,24 @@ UM.Dialog {
             }
         }
 
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Include Snapshot of Model."
+
+            CheckBox
+            {
+                id: includeSnapshotCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_snapshot")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_snapshot",  checked)
+
+                text: "Include Model Snapshot"
+            }
+        }
+
         Item
         {
             //: Spacer
@@ -190,6 +208,9 @@ UM.Dialog {
 
                 UM.Preferences.resetPreference("3d_print_log/include_filament_name")
                 includeFilamentNameCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_filament_name")
+
+                UM.Preferences.resetPreference("3d_print_log/include_snapshot")
+                includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
                 
                 settingsDialog.visible = false;
             }


### PR DESCRIPTION
Implemented the capturing of Snapshots of the workspace within Cura, which will be recorded as the default Print Image when sent to 3D Print Log.

Adds a new menu option for "Include Snapshot" to the setting menu, which is enabled by default.

Thanks to the suggestion by cospav in issue #4. 