### PR TITLE
Add backwards compatibility for Cura 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Re-adds backward compatibility support for Cura 4
+
 ## 2.0.0
 
 ### Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.1
 
-- Re-adds backward compatibility support for Cura 4
+- Adds new setting which skips the "Do you want to send to 3D Print Log?" prompt and always send print information after saving.
+- Adds backward compatibility support for Cura 4
 
 ## 2.0.0
 

--- a/PrintLogUploader.py
+++ b/PrintLogUploader.py
@@ -104,6 +104,11 @@ class PrintLogUploader(QObject, Extension):
             True
         )
 
+        self._application.getPreferences().addPreference(
+            "3d_print_log/bypass_prompt",
+            False
+        )
+
         self._application.engineCreatedSignal.connect(self._onEngineCreated)
 
     def _onSendMenuButtonClicked(self):
@@ -203,11 +208,20 @@ class PrintLogUploader(QObject, Extension):
         if not hasSliced:
             return False
 
+        preferences = self._application.getInstance().getPreferences()
+        bypass_prompt = preferences.getValue(
+                "3d_print_log/bypass_prompt")
+        if (bypass_prompt):
+                return True
+
         dialog = self._createConfirmationDialog()
 
         returnValue = dialog.exec()
-
-        return returnValue == QMessageBox.Ok
+        
+        if USE_QT5:
+            return returnValue == QMessageBox.Ok
+        else:
+            return returnValue == QMessageBox.StandardButton.Ok
 
     def _hasSlicedModel(self) -> bool:
         '''Checks to see if the model has been sliced'''
@@ -224,11 +238,11 @@ class PrintLogUploader(QObject, Extension):
     def _createConfirmationDialog(self):
         '''Create a message box prompting the user if they want to send this print information.'''
         msgBox = QMessageBox()
-        msgBox.setIcon(QMessageBox.Information)
+        msgBox.setIcon(QMessageBox.Information if USE_QT5 else QMessageBox.Icon.Information)
         msgBox.setText("Would you like to send to 3Dprintlog.com?")
         msgBox.setWindowTitle("Send to 3D Print Log?")
-        msgBox.setStandardButtons(QMessageBox.Ok | QMessageBox.Cancel)
-        msgBox.setDefaultButton(QMessageBox.Ok)
+        msgBox.setStandardButtons((QMessageBox.Ok if USE_QT5 else QMessageBox.StandardButton.Ok) | (QMessageBox.Cancel if USE_QT5 else QMessageBox.StandardButton.Cancel))
+        msgBox.setDefaultButton(QMessageBox.Ok if USE_QT5 else QMessageBox.StandardButton.Ok)
 
         self._add3DPrintLogLogo(msgBox)
 
@@ -237,11 +251,11 @@ class PrintLogUploader(QObject, Extension):
     def _createDialog(self, text, title):
         '''Create a messsage box with a title and text'''
         msgBox = QMessageBox()
-        msgBox.setIcon(QMessageBox.Information)
+        msgBox.setIcon(QMessageBox.Information if USE_QT5 else QMessageBox.Icon.Information)
         msgBox.setText(text)
         msgBox.setWindowTitle(title)
-        msgBox.setStandardButtons(QMessageBox.Ok)
-        msgBox.setDefaultButton(QMessageBox.Ok)
+        msgBox.setStandardButtons((QMessageBox.Ok if USE_QT5 else QMessageBox.StandardButton.Ok))
+        msgBox.setDefaultButton((QMessageBox.Ok if USE_QT5 else QMessageBox.StandardButton.Ok))
 
         self._add3DPrintLogLogo(msgBox)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,7 +1,12 @@
 from . import PrintLogUploader
 from . import PrintLogSettingDefinitionsModel
 
-from PyQt6.QtQml import qmlRegisterType
+USE_QT5 = False
+try:
+    from PyQt6.QtQml import qmlRegisterType
+except ImportError:
+    from PyQt5.QtQml import qmlRegisterType
+    USE_QT5 = True
 
 
 def getMetaData():

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Send Print details to 3D Print Log",
-  "supported_sdk_versions": ["8.0.0"]
+  "supported_sdk_versions": ["7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0", "8.0.0"]
 }

--- a/qml/qt5/SettingCategory.qml
+++ b/qml/qt5/SettingCategory.qml
@@ -1,7 +1,9 @@
+
 import QtQuick 2.2
 import QtQuick.Controls 1.1
 import QtQuick.Controls.Styles 1.1
 import QtQuick.Layouts 1.1
+
 
 import UM 1.1 as UM
 

--- a/qml/qt5/SettingItem.qml
+++ b/qml/qt5/SettingItem.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.1
 import QtQuick.Layouts 1.1
 import QtQuick.Controls 1.1
-import QtQuick.Controls.Styles 1.1
 
 import UM 1.2 as UM
 

--- a/qml/qt5/SettingsDialog.qml
+++ b/qml/qt5/SettingsDialog.qml
@@ -98,6 +98,24 @@ UM.Dialog {
             }
         }
 
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Bypass the 'Do you want to send to 3D Print Log' prompt."
+
+            CheckBox
+            {
+                id: bypassPromptCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/bypass_prompt")
+                onClicked: UM.Preferences.setValue("3d_print_log/bypass_prompt",  checked)
+
+                text: "Always send to 3D Print Log after saving file"
+            }
+        }
+
         Item
         {
             //: Spacer
@@ -210,6 +228,10 @@ UM.Dialog {
 
                 UM.Preferences.resetPreference("3d_print_log/include_snapshot")
                 includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
+
+                UM.Preferences.resetPreference("3d_print_log/bypass_prompt")
+                bypassPromptCheckbox.checked = UM.Preferences.getValue("3d_print_log/bypass_prompt")
+                
                 
                 settingsDialog.visible = false;
             }

--- a/qml/qt5/SettingsDialog.qml
+++ b/qml/qt5/SettingsDialog.qml
@@ -1,6 +1,5 @@
 import QtQuick 2.2
 import QtQuick.Controls 1.2
-import QtQuick.Controls.Styles 1.2
 import QtQuick.Window 2.2
 import QtQuick.Layouts 1.1
 

--- a/qml/qt6/SettingCategory.qml
+++ b/qml/qt6/SettingCategory.qml
@@ -1,0 +1,58 @@
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import UM as UM
+
+import ".."
+
+Button {
+    id: base;
+
+    background: Item { }
+    label: Row
+    {
+        spacing: UM.Theme.getSize("default_lining").width
+
+        UM.ColorImage
+        {
+            anchors.verticalCenter: parent.verticalCenter
+            height: (label.height / 2) | 0
+            width: height
+            source: control.checked ? UM.Theme.getIcon("arrow_bottom") : UM.Theme.getIcon("arrow_right");
+            color: control.hovered ? palette.highlight : palette.buttonText
+        }
+        UM.ColorImage
+        {
+            anchors.verticalCenter: parent.verticalCenter
+            height: label.height
+            width: height
+            source: control.iconSource
+            color: control.hovered ? palette.highlight : palette.buttonText
+        }
+        Label
+        {
+            id: label
+            anchors.verticalCenter: parent.verticalCenter
+            text: control.text
+            color: control.hovered ? palette.highlight : palette.buttonText
+            font.bold: true
+        }
+
+        SystemPalette { id: palette }
+    }
+    
+
+    signal showTooltip(string text);
+    signal hideTooltip();
+    signal contextMenuRequested()
+
+    text: definition.label
+    iconSource: UM.Theme.getIcon("arrow_bottom")
+
+    checkable: true
+    checked: definition.expanded
+
+    onClicked: definition.expanded ? settingDefinitionsModel.collapse(definition.key) : settingDefinitionsModel.expandRecursive(definition.key)
+}

--- a/qml/qt6/SettingItem.qml
+++ b/qml/qt6/SettingItem.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
+
+import UM as UM
+
+UM.TooltipArea
+{
+    x: model.depth * UM.Theme.getSize("default_margin").width;
+    text: model.description;
+
+    width: childrenRect.width;
+    height: childrenRect.height;
+
+    CheckBox
+    {
+        id: check
+
+        text: definition.label
+        checked: definition.visible;
+
+        onClicked:
+        {
+            definitionsModel.visibilityHandler.setSettingVisibility(model.key, checked);
+        }
+    }
+}
+
+

--- a/qml/qt6/SettingsDialog.qml
+++ b/qml/qt6/SettingsDialog.qml
@@ -1,0 +1,235 @@
+import QtQuick 
+import QtQuick.Controls
+import QtQuick.Window 
+import QtQuick.Layouts 
+
+import UM  as UM
+import Cura  as Cura
+import PrintLogUploader  as PrintLogUploader
+
+UM.Dialog {
+    id: settingsDialog
+
+    title: catalog.i18nc("@title:window", "Select Settings to Log")
+    width: screenScaleFactor * 360
+
+    onVisibilityChanged:
+    {
+        if(visible)
+        {
+            updateFilter()
+        }
+    }
+
+    function updateFilter()
+    {
+        var new_filter = {};
+
+        if(filterInput.text != "")
+        {
+            new_filter["i18n_label"] = "*" + filterInput.text;
+        }
+
+        listview.model.filter = new_filter;
+    }
+
+    ColumnLayout
+    {
+        anchors.fill: parent
+
+        Label
+        {
+            font.bold: true
+            text: "General"
+        }
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Include profile name in the Notes field."
+
+            CheckBox
+            {
+                id: includeProfileNameCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_profile_name")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_profile_name", checked)
+
+                text: "Include Profile Name"
+            }
+        }
+
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Include filament/material name in the Notes field."
+
+            CheckBox
+            {
+                id: includeFilamentNameCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_filament_name")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_filament_name",  checked)
+
+                text: "Include Filament Name"
+            }
+        }
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Include Snapshot of Model."
+
+            CheckBox
+            {
+                id: includeSnapshotCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_snapshot")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_snapshot",  checked)
+
+                text: "Include Model Snapshot"
+            }
+        }
+
+        Item
+        {
+            //: Spacer
+            height: UM.Theme.getSize("default_margin").height
+            width: UM.Theme.getSize("default_margin").width
+        }
+
+        Label
+        {
+            id: settingLabel
+            font.bold: true
+            text: "Settings"
+        }
+
+        Row {
+            id: settingSearchRow
+            Layout.fillWidth: true
+
+            TextField {
+
+                id: filterInput
+                width: settingSearchRow.width - searchSpacer.width - toggleShowAll.width
+                placeholderText: catalog.i18nc("@label:textbox", "Filter...");
+
+                onTextChanged: settingsDialog.updateFilter()
+            }
+
+            Item
+            {
+                id: searchSpacer
+                //: Spacer
+                height: UM.Theme.getSize("default_margin").height
+                width: UM.Theme.getSize("default_margin").width
+            }
+
+            CheckBox
+            {
+                id: toggleShowAll
+                
+                text: catalog.i18nc("@label:checkbox", "Show all")
+                checked: listview.model.showAll
+                onClicked:
+                {
+                    listview.model.showAll = checked;
+                }
+            }
+        }
+
+        ScrollView
+        {
+            id: scrollView
+            Layout.fillHeight: true
+            Layout.fillWidth: true
+
+            ListView
+            {
+                id:listview
+                model: PrintLogUploader.PrintLogSettingDefinitionsModel
+                {
+                    id: definitionsModel;
+                    containerId: Cura.MachineManager.activeMachine.definition.id
+                    visibilityHandler: Cura.PrintLogSettingsVisibilityHandler {}
+                    showAll: true
+                    showAncestors: true
+                    expanded: [ "*" ]
+                    exclude: [ "machine_settings", "command_line_settings" ]
+                }
+                delegate:Loader
+                {
+                    id: loader
+
+                    width: parent.width
+                    height: model.type != undefined ? UM.Theme.getSize("section").height : 0;
+
+                    property var definition: model
+                    property var settingDefinitionsModel: definitionsModel
+
+                    asynchronous: true
+                    source:
+                    {
+                        switch(model.type)
+                        {
+                            case "category":
+                                return "SettingCategory.qml"
+                            default:
+                                return "SettingItem.qml"
+                        }
+                    }
+                }
+                Component.onCompleted: settingsDialog.updateFilter()
+            }
+        }
+    }
+    
+    rightButtons: [
+        Button {
+            anchors {
+                rightMargin: UM.Theme.getSize("default_margin").width
+            }
+            
+            text: catalog.i18nc("@action:button", "Reset To Defaults");
+            onClicked: {
+                UM.Preferences.resetPreference("3d_print_log/logged_settings")
+                
+                UM.Preferences.resetPreference("3d_print_log/include_profile_name")
+                includeProfileNameCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_profile_name")
+
+                UM.Preferences.resetPreference("3d_print_log/include_filament_name")
+                includeFilamentNameCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_filament_name")
+
+                UM.Preferences.resetPreference("3d_print_log/include_snapshot")
+                includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
+                
+                settingsDialog.visible = false;
+            }
+        },
+        Item
+        {
+            //: Spacer
+            height: UM.Theme.getSize("default_margin").height
+            width: UM.Theme.getSize("default_margin").width
+        },
+        Button {
+            text: catalog.i18nc("@action:button", "Close");
+            onClicked: {
+                settingsDialog.visible = false;
+            }
+        }
+    ]
+
+    Item
+    {
+        UM.I18nCatalog { id: catalog; name: "cura"; }
+    }
+}

--- a/qml/qt6/SettingsDialog.qml
+++ b/qml/qt6/SettingsDialog.qml
@@ -98,6 +98,24 @@ UM.Dialog {
             }
         }
 
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
+            text: "Bypass the 'Do you want to send to 3D Print Log' prompt."
+
+            CheckBox
+            {
+                id: bypassPromptCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/bypass_prompt")
+                onClicked: UM.Preferences.setValue("3d_print_log/bypass_prompt",  checked)
+
+                text: "Always send to 3D Print Log after saving file"
+            }
+        }
+
         Item
         {
             //: Spacer
@@ -210,6 +228,9 @@ UM.Dialog {
 
                 UM.Preferences.resetPreference("3d_print_log/include_snapshot")
                 includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
+
+                UM.Preferences.resetPreference("3d_print_log/bypass_prompt")
+                bypassPromptCheckbox.checked = UM.Preferences.getValue("3d_print_log/bypass_prompt")
                 
                 settingsDialog.visible = false;
             }


### PR DESCRIPTION
Following patterns from other Cura Plugin devs, I've added the ability to fall back to Qt5 Support for when the plugin is loaded through Cura 4.