### PR TITLE
Add prompt settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.2
+
+- Adds new option to bypass the "Would you like to send to 3D Print Log" prompt, with an option to 'Always Ask', to 'Always Send after save', or 'Never Send after save'.
+- Removes the old Bypass Prompt checkbox, since the new dropdown replaces it.
+
 ## 2.0.1
 
 - Adds new setting which skips the "Do you want to send to 3D Print Log?" prompt and always send print information after saving.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Send Print details to 3D Print Log",
   "supported_sdk_versions": ["7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0", "8.0.0"]
 }

--- a/qml/qt5/SettingsDialog.qml
+++ b/qml/qt5/SettingsDialog.qml
@@ -103,16 +103,69 @@ UM.Dialog {
             width: childrenRect.width;
             height: childrenRect.height;
 
-            text: "Bypass the 'Do you want to send to 3D Print Log' prompt."
+            text: "Should we display a prompt after saving gcode?"
 
-            CheckBox
+            GridLayout
             {
-                id: bypassPromptCheckbox
+                id: interfaceGrid
+                columns: 2
+                width: parent.width
 
-                checked: UM.Preferences.getValue("3d_print_log/bypass_prompt")
-                onClicked: UM.Preferences.setValue("3d_print_log/bypass_prompt",  checked)
+                Label
+                {
+                    id: promptSettingsLabel
+                    text: "Log Print after Gcode Save"
+                }
 
-                text: "Always send to 3D Print Log after saving file"
+                
+
+                ComboBox
+                {
+                    id: promptSettingsComboBox
+
+                    textRole: "text"
+                    model: ListModel
+                    {
+                        id: promptList
+
+                        Component.onCompleted:
+                        {
+                            append({ text: "Always Ask", code: "always_ask" })
+                            append({ text: "Always Send to 3D Print Log", code: "send_after_save" })
+                            append({ text: "Never Send to 3D Print Log", code: "do_not_send" })
+                        }
+                    }
+
+                    currentIndex: {
+                        var code = UM.Preferences.getValue("3d_print_log/prompt_settings");
+                        for(var i = 0; i < promptList.count; ++i)
+                        {
+                            if(model.get(i).code == code)
+                            {
+                                return i
+                            }
+                        }
+                    }
+
+                    onActivated:
+                    {
+                        if (model.get(index).code != "")
+                        {
+                            UM.Preferences.setValue("3d_print_log/prompt_settings", model.get(index).code);
+                        }
+                        else
+                        {
+                            var code = UM.Preferences.getValue("3d_print_log/prompt_settings");
+                            for(var i = 0; i < promptList.count; ++i)
+                            {
+                                if(model.get(i).code == code)
+                                {
+                                    currentIndex = i
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -229,10 +282,9 @@ UM.Dialog {
                 UM.Preferences.resetPreference("3d_print_log/include_snapshot")
                 includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
 
-                UM.Preferences.resetPreference("3d_print_log/bypass_prompt")
-                bypassPromptCheckbox.checked = UM.Preferences.getValue("3d_print_log/bypass_prompt")
-                
-                
+                UM.Preferences.resetPreference("3d_print_log/prompt_settings")
+                promptSettingsComboBox.setCurrentIndex()
+
                 settingsDialog.visible = false;
             }
         },

--- a/qml/qt6/SettingsDialog.qml
+++ b/qml/qt6/SettingsDialog.qml
@@ -103,18 +103,69 @@ UM.Dialog {
             width: childrenRect.width;
             height: childrenRect.height;
 
-            text: "Bypass the 'Do you want to send to 3D Print Log' prompt."
+            text: "Should we display a prompt after saving gcode?"
 
-            CheckBox
+            GridLayout
             {
-                id: bypassPromptCheckbox
+                id: interfaceGrid
+                columns: 2
+                width: parent.width
 
-                checked: UM.Preferences.getValue("3d_print_log/bypass_prompt")
-                onClicked: UM.Preferences.setValue("3d_print_log/bypass_prompt",  checked)
+                UM.Label
+                {
+                    id: promptSettingsLabel
+                    text: "Log Print after Gcode Save"
+                }
 
-                text: "Always send to 3D Print Log after saving file"
+                ListModel
+                {
+                    id: promptList
+
+                    Component.onCompleted:
+                    {
+                        append({ text: "Always Ask", code: "always_ask" })
+                        append({ text: "Always Send to 3D Print Log", code: "send_after_save" })
+                        append({ text: "Never Send to 3D Print Log", code: "do_not_send" })
+                    }
+                }
+
+                Cura.ComboBox
+                {
+                    id: promptSettingsComboBox
+
+                    textRole: "text"
+                    model: promptList
+                    implicitWidth: UM.Theme.getSize("combobox").width
+
+                    function setCurrentIndex() {
+                        var code = UM.Preferences.getValue("3d_print_log/prompt_settings");
+                        for(var i = 0; i < promptList.count; ++i)
+                        {
+                            if(model.get(i).code == code)
+                            {
+                                return i
+                            }
+                        }
+                    }
+
+                    currentIndex: setCurrentIndex()
+
+                    onActivated:
+                    {
+                        if (model.get(index).code != "")
+                        {
+                            UM.Preferences.setValue("3d_print_log/prompt_settings", model.get(index).code);
+                        }
+                        else
+                        {
+                            currentIndex = setCurrentIndex();
+                        }
+                    }
+                }
             }
         }
+
+
 
         Item
         {
@@ -229,9 +280,9 @@ UM.Dialog {
                 UM.Preferences.resetPreference("3d_print_log/include_snapshot")
                 includeSnapshotCheckbox.checked = UM.Preferences.getValue("3d_print_log/include_snapshot")
 
-                UM.Preferences.resetPreference("3d_print_log/bypass_prompt")
-                bypassPromptCheckbox.checked = UM.Preferences.getValue("3d_print_log/bypass_prompt")
-                
+                UM.Preferences.resetPreference("3d_print_log/prompt_settings")
+                promptSettingsComboBox.setCurrentIndex()
+
                 settingsDialog.visible = false;
             }
         },


### PR DESCRIPTION
Thanks to the suggestion of @m-roberts in #6, this adds a new dropdown in the settings for the "Log Print after Gcode Save", which has the option to "Always Ask", "Always Send after Save", and "Never Send After Save".