### PR TITLE
Added a fallback to display a dialog with the URL when the webbrowser…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.4
+
+- Added a dialog which displays the New Print Url when the plugin was unable to automatically detect and open the webbrowser.
+
 ## 2.0.3
 
 - Fix the Settings dialog to properly display the Setting Category.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Send Print details to 3D Print Log",
   "supported_sdk_versions": ["7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0", "8.0.0"]
 }


### PR DESCRIPTION
A user mentioned that their Cura was not sending prints to 3D Print Log. After debugging, we saw that the plugin was sometimes not able to open a new browser tab to load the new-print page. 

This adds a fallback dialog to display the URL that the user _should_ have been sent to, when we detect that we didn't automatically open the page.