### PR TITLE
Object Details in Notes

### DIFF
--- a/.github/workflows/create_tagged_release_with_packages.yaml
+++ b/.github/workflows/create_tagged_release_with_packages.yaml
@@ -1,0 +1,27 @@
+name: "Cura-plugin release"
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  create-curapackages:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: "build"
+          submodules: "recursive"
+      - uses: fieldOfView/cura-plugin-packager-action@main
+        with:
+          source_folder: "build"
+          package_info_path: "build/.github/workflows/package.json"
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            *.curapackage

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -1,0 +1,16 @@
+{
+  "author": {
+    "author_id": "ChristopherHoffman",
+    "display_name": "Christopher Hoffman",
+    "email": "hello@3dprintlog.com",
+    "website": "https://www.3dpringlog.com"
+  },
+  "description": "Send Print details to 3D Print Log",
+  "display_name": "3D Print Log Uploader",
+  "package_id": "3dPrintLogUploader",
+  "package_type": "plugin",
+  "package_version": "0.0.0",
+  "sdk_version": 0,
+  "sdk_version_semver": "0.0.0",
+  "website": "https://github.com/ChristopherHoffman/3d-print-log-cura-plugin"
+}

--- a/PrintLogUploader.py
+++ b/PrintLogUploader.py
@@ -113,6 +113,11 @@ class PrintLogUploader(QObject, Extension):
             "always_ask"
         )
 
+        self._application.getPreferences().addPreference(
+            "3d_print_log/include_object_details",
+            True
+        )
+
         # Transfer deprecated bypass_prompt to the new combobox value:
         bypass_prompt = self._application.getPreferences().getValue(
                 "3d_print_log/bypass_prompt")
@@ -622,31 +627,9 @@ class PrintLogUploader(QObject, Extension):
                 notes = notes + "Filament: " + ", ".join(materials) + "\n\n"
 
         # Add Model Dimensions
-        models = self._getModelInformation()
-        if len(models["models"]) > 0:
-            notes = notes + "Models:\n"
-        for model in models["models"]:
-            notes = notes + "  " + model["name"] + "\n"
-            notes = notes + "    Move: " + "{:.4f}".format(model["bounding_box"]["translation"]["x"]).rstrip('0').rstrip('.') + " x, " \
-                + "{:.4f}".format(model["bounding_box"]["translation"]["y"]).rstrip('0').rstrip('.') + " y, " \
-                + "{:.4f}".format(model["bounding_box"]["translation"]["z"]).rstrip('0').rstrip('.') + " z\n"
-            
-            notes = notes + "    Scale: " + "{:.4f}".format(model["bounding_box"]["scale"]["x"]).rstrip('0').rstrip('.') + " x, " \
-                + "{:.4f}".format(model["bounding_box"]["scale"]["y"]).rstrip('0').rstrip('.') + " y, " \
-                + "{:.4f}".format(model["bounding_box"]["scale"]["z"]).rstrip('0').rstrip('.') + " z\n"
-
-
-                            # model["bounding_box"] = {
-                            #             "translation": {"x": bounding_box.center.x,
-                            #                         "y":bounding_box.center.z,
-                            #                         "z":bounding_box.bottom},
-                            #             "scale": {"x": bounding_box.width,
-                            #                     "y": bounding_box.depth,
-                            #                     "z": bounding_box.height}
-
-        if len(models["models"]) > 0:
-            notes = notes + "\n\n"
-
+        include_object_details = preferences.getValue("3d_print_log/include_object_details")
+        if (include_object_details):
+            notes = notes + self._getObjectNotes()
 
         # Add settings to the notes.
         notes = notes + "Settings:\n"
@@ -764,3 +747,33 @@ class PrintLogUploader(QObject, Extension):
             isFirst = False
 
         return result
+
+    def _getObjectNotes(self) -> str:
+        notes = ""
+
+        models = self._getModelInformation()
+
+        if len(models["models"]) > 0:
+            notes = notes + "Objects:\n"
+
+        for model in models["models"]:
+            notes = notes + "  " + model["name"] + "\n"
+
+            translation = model["bounding_box"]["translation"]
+            notes = notes + "    Move: " + self._formatNumber(translation["x"], 4) + " x, " \
+                +  self._formatNumber(translation["y"], 4) + " y, " \
+                +  self._formatNumber(translation["z"], 4) + " z\n"
+            
+            scale = model["bounding_box"]["scale"]
+            notes = notes + "    Scale: " + self._formatNumber(scale["x"], 4) + " x, " \
+                + self._formatNumber(scale["y"], 4) + " y, " \
+                + self._formatNumber(scale["z"], 4) + " z\n"
+
+        if len(models["models"]) > 0:
+            notes = notes + "\n\n"
+        
+        return notes
+    
+    def _formatNumber(self, number, numberOfDigitsToDisplay) -> str:
+        '''Formats a number to the specified number of digits, trimming any trailing 0's'''
+        return ("{:.%sf}" % numberOfDigitsToDisplay).format(number).rstrip('0').rstrip('.')

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "3D Print Log",
   "author": "Hoffman Engineering",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Send Print details to 3D Print Log",
   "supported_sdk_versions": ["7.1.0", "7.2.0", "7.3.0", "7.4.0", "7.5.0", "8.0.0"]
 }

--- a/qml/qt5/SettingsDialog.qml
+++ b/qml/qt5/SettingsDialog.qml
@@ -103,6 +103,24 @@ UM.Dialog {
             width: childrenRect.width;
             height: childrenRect.height;
 
+            text: "Include object names, position, and scale information in the notes."
+
+            UM.CheckBox
+            {
+                id: includeSnapshotCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_object_details")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_object_details",  checked)
+
+                text: "Include Object Details in Notes"
+            }
+        }
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
             text: "Should we display a prompt after saving gcode?"
 
             GridLayout

--- a/qml/qt5/SettingsDialog.qml
+++ b/qml/qt5/SettingsDialog.qml
@@ -107,7 +107,7 @@ UM.Dialog {
 
             UM.CheckBox
             {
-                id: includeSnapshotCheckbox
+                id: includeObjectDetails
 
                 checked: UM.Preferences.getValue("3d_print_log/include_object_details")
                 onClicked: UM.Preferences.setValue("3d_print_log/include_object_details",  checked)

--- a/qml/qt6/SettingsDialog.qml
+++ b/qml/qt6/SettingsDialog.qml
@@ -109,7 +109,7 @@ UM.Dialog {
 
             UM.CheckBox
             {
-                id: includeSnapshotCheckbox
+                id: includeObjectDetails
 
                 checked: UM.Preferences.getValue("3d_print_log/include_object_details")
                 onClicked: UM.Preferences.setValue("3d_print_log/include_object_details",  checked)

--- a/qml/qt6/SettingsDialog.qml
+++ b/qml/qt6/SettingsDialog.qml
@@ -105,6 +105,24 @@ UM.Dialog {
             width: childrenRect.width;
             height: childrenRect.height;
 
+            text: "Include object names, position, and scale information in the notes."
+
+            UM.CheckBox
+            {
+                id: includeSnapshotCheckbox
+
+                checked: UM.Preferences.getValue("3d_print_log/include_object_details")
+                onClicked: UM.Preferences.setValue("3d_print_log/include_object_details",  checked)
+
+                text: "Include Object Details in Notes"
+            }
+        }
+
+        UM.TooltipArea
+        {
+            width: childrenRect.width;
+            height: childrenRect.height;
+
             text: "Should we display a prompt after saving gcode?"
 
             GridLayout


### PR DESCRIPTION
## 2.0.5

- Adds a new "Include Object Details in Notes" setting, which is enabled by default. This will add the stl name, position, and size information directly within the Notes section went sent to 3D Print Log.
- Sends the currently selected machine ID for a future 3D Print Log feature which will automatically select the correct printer.